### PR TITLE
fix: change import of get-port to dynamic import for playwrite

### DIFF
--- a/.changeset/smooth-colts-play.md
+++ b/.changeset/smooth-colts-play.md
@@ -2,6 +2,6 @@
 "@viem/anvil": patch
 ---
 
-As playwrite imports CJS in global setup it will throw the error Error: require() of ES Module changed import to dynamic import.
+As Playwright imports CJS in global setup it will throw the error Error: require() of ES Module changed import to dynamic import.
 * Removed the import of getPort from `"get-port"`
 * Updated the port property to use `import("get-port").default` instead of `getPort()`

--- a/.changeset/smooth-colts-play.md
+++ b/.changeset/smooth-colts-play.md
@@ -1,0 +1,7 @@
+---
+"@viem/anvil": patch
+---
+
+As playwrite imports CJS in global setup it will throw the error Error: require() of ES Module changed import to dynamic import.
+* Removed the import of getPort from `"get-port"`
+* Updated the port property to use `import("get-port").default` instead of `getPort()`

--- a/packages/anvil.js/src/pool/createPool.ts
+++ b/packages/anvil.js/src/pool/createPool.ts
@@ -3,7 +3,6 @@ import {
   type CreateAnvilOptions,
   createAnvil,
 } from "../anvil/createAnvil.js";
-import getPort from "get-port";
 
 /**
  * A pool of anvil instances.
@@ -96,7 +95,7 @@ export function createPool<TKey = number>({
           ...options,
           ...(options?.port === undefined && autoPort
             ? {
-                port: await getPort(),
+                port:  await ((await import("get-port")).default)(),
               }
             : {}),
         };


### PR DESCRIPTION
As playwrite imports CJS in global setup it will throw the error `Error: require() of ES Module` changed import to dynamic import.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Removed the import of `getPort` from `"get-port"`
- Updated the `port` property to use `import("get-port").default` instead of `getPort()`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->