### PR TITLE
docs: fix the link to Anvil in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AnvilJS
 
-TypeScript wrapper for Foundry [Anvil](https://github.com/foundry-rs/foundry/tree/master/anvil). AnvilJS provides a simple API to create and manage Anvil instances programmatically.
+TypeScript wrapper for Foundry [Anvil](https://github.com/foundry-rs/foundry/tree/master/crates/anvil). AnvilJS provides a simple API to create and manage Anvil instances programmatically.
 
 ```ts
 import { createAnvil } from "@viem/anvil";


### PR DESCRIPTION
As simple as it states: try the Anvil link on top of the readme, it's broken; this PR suggests the up-to-date link instead.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the link to the Anvil crate in the README file. 

### Detailed summary
- Updated the link to the Anvil crate from `foundry-rs/foundry/tree/master/anvil` to `foundry-rs/foundry/tree/master/crates/anvil`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->