### PR TITLE
feat(anvil.js): Add support for specifying headers in fork mode

### DIFF
--- a/.changeset/odd-bears-relax.md
+++ b/.changeset/odd-bears-relax.md
@@ -1,0 +1,5 @@
+---
+"@viem/anvil": patch
+---
+
+Added support for specifying headers in fork mode

--- a/packages/anvil.js/src/anvil/createAnvil.ts
+++ b/packages/anvil.js/src/anvil/createAnvil.ts
@@ -106,6 +106,14 @@ export type AnvilOptions = {
    */
   forkChainId?: number | undefined;
   /**
+   * Specify headers to send along with any request to the remote JSON-RPC server in forking mode.
+   * 
+   * e.g. "User-Agent: test-agent"
+   * 
+   * Requires `forkUrl` to be set.
+   */
+  forkHeader?: Record<string, string> | undefined;
+  /**
    * Initial retry backoff on encountering errors.
    */
   forkRetryBackoff?: number | undefined;

--- a/packages/anvil.js/src/anvil/toArgs.ts
+++ b/packages/anvil.js/src/anvil/toArgs.ts
@@ -7,11 +7,25 @@ import { toFlagCase } from "./toFlagCase.js";
  * @returns The command line arguments.
  */
 export function toArgs(options: {
-  [key: string]: string | boolean | number | bigint | undefined;
+  [key: string]: Record<string, string> | string | boolean | number | bigint | undefined;
 }) {
   return Object.entries(options).flatMap(([key, value]) => {
     if (value === undefined) {
       return [];
+    }
+
+    if(typeof value === "object" && value !== null) {
+      return Object.entries(value).flatMap(([subKey, subValue]) => {
+        if (subValue === undefined) {
+          return [];
+        }
+
+        const flag = toFlagCase(key);
+
+        const value = `${subKey}: ${subValue}`;
+
+        return [flag, value];
+      });
     }
 
     const flag = toFlagCase(key);

--- a/packages/anvil.js/src/anvil/toArgs.ts
+++ b/packages/anvil.js/src/anvil/toArgs.ts
@@ -14,7 +14,7 @@ export function toArgs(options: {
       return [];
     }
 
-    if(typeof value === "object" && value !== null) {
+    if (typeof value === "object" && value !== null) {
       return Object.entries(value).flatMap(([subKey, subValue]) => {
         if (subValue === undefined) {
           return [];


### PR DESCRIPTION
This adds the ability to pass headers for the fork url to the underlying anvil instance.

This does not seem to be documented in the anvil reference however it is [available in anvil as a command line option](https://github.com/foundry-rs/foundry/blob/master/crates/anvil/src/cmd.rs#L370)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `@viem/anvil` package by adding support for specifying headers in fork mode and updating the `toArgs` function to handle nested objects.

### Detailed summary
- Added `forkHeader` option to specify headers in fork mode
- Updated `toArgs` function to handle nested objects in options

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->