### PR TITLE
feat: add autoImpersonate flag

### DIFF
--- a/.changeset/dry-donkeys-repair.md
+++ b/.changeset/dry-donkeys-repair.md
@@ -2,4 +2,4 @@
 "@viem/anvil": minor
 ---
 
-Add autoImpersonate option to AnvilOptions
+Added `autoImpersonate` property.

--- a/.changeset/dry-donkeys-repair.md
+++ b/.changeset/dry-donkeys-repair.md
@@ -1,0 +1,5 @@
+---
+"@viem/anvil": minor
+---
+
+Add autoImpersonate option to AnvilOptions

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "editor.defaultFormatter": "rome.rome",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports.rome": true
+    "source.organizeImports.rome": "explicit"
   },
   "[typescript]": {
     "editor.defaultFormatter": "rome.rome"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "editor.defaultFormatter": "rome.rome",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports.rome": "explicit"
+    "source.organizeImports.rome": true
   },
   "[typescript]": {
     "editor.defaultFormatter": "rome.rome"

--- a/packages/anvil.js/src/anvil/createAnvil.ts
+++ b/packages/anvil.js/src/anvil/createAnvil.ts
@@ -278,6 +278,10 @@ export type AnvilOptions = {
    * Number of blocks with transactions to keep in memory.
    */
   transactionBlockKeeper?: number | undefined;
+  /**
+   * Enable autoImpersonate on startup
+   */
+  autoImpersonate?: boolean | undefined;
 };
 
 export type CreateAnvilOptions = AnvilOptions & {

--- a/packages/anvil.js/src/anvil/createAnvil.ts
+++ b/packages/anvil.js/src/anvil/createAnvil.ts
@@ -79,6 +79,10 @@ type Hardfork =
 
 export type AnvilOptions = {
   /**
+   * Enable autoImpersonate on startup
+   */
+  autoImpersonate?: boolean | undefined;
+  /**
    * Sets the number of assumed available compute units per second for this fork provider.
    *
    * @defaultValue 350
@@ -278,10 +282,6 @@ export type AnvilOptions = {
    * Number of blocks with transactions to keep in memory.
    */
   transactionBlockKeeper?: number | undefined;
-  /**
-   * Enable autoImpersonate on startup
-   */
-  autoImpersonate?: boolean | undefined;
 };
 
 export type CreateAnvilOptions = AnvilOptions & {


### PR DESCRIPTION
Anvil allows an `autoImpersonate` flag. This is really useful for simulating transactions from accounts that aren't already unlocked. See the docs here: https://book.getfoundry.sh/reference/anvil/#options

This PR adds the `--auto-impersonate` flag

Thanks!

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds the `autoImpersonate` property to `AnvilOptions` in `createAnvil.ts` for enabling auto impersonation feature.

### Detailed summary
- Added `autoImpersonate` property to `AnvilOptions`
- Implemented test for starting anvil with auto impersonation
- Updated `createAnvilClients` to support auto impersonation functionality

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->